### PR TITLE
Bulk upload for shapefiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Startups working with Esri and ArcGIS implement many common workflows. The [ArcG
   * [`configure_org.ipynb`](/build_org/configure_org.ipynb) - Jupyter Notebook to customize org UI & add users
 * [`bulk_csv/`](/bulk_csv) - Upload a lot of CSVs
   * [`bulk_csv_upload.ipynb`](/bulk_csv/bulk_csv_upload.ipynb) - Jupyter Notebook to upload a folder of CSVs to [hosted feature layers](https://doc.arcgis.com/en/arcgis-online/share-maps/hosted-web-layers.htm) in your GIS
+* [`bulk_shp/`](/bulk_csv) - Upload a lot of Shapefiles
+  * [`bulk_shapefile_upload.ipynb`](/bulk_shp/bulk_shapefile_upload.ipynb) - Jupyter Notebook to upload a folder of Shapefiles to [hosted feature layers](https://doc.arcgis.com/en/arcgis-online/share-maps/hosted-web-layers.htm) in your GIS
 
 
 ## Getting Started

--- a/bulk_shp/README.md
+++ b/bulk_shp/README.md
@@ -1,0 +1,10 @@
+## Getting Started
+
+### Jupyter Notebooks _(local)_:
+
+1. `$ git clone https://github.com/mpayson/startup-python-tools.git`
+2. `$ cd startup-python-tools/bulk_shp`
+3. `$ jupyter notebook`
+4. Open `bulk_shapefile_upload.ipynb`
+5. Update GIS information and user-defined constants
+6. Run!

--- a/bulk_shp/bulk_shapefile_upload.ipynb
+++ b/bulk_shp/bulk_shapefile_upload.ipynb
@@ -19,7 +19,6 @@
     "# common imports\n",
     "import os\n",
     "from arcgis.gis import *\n",
-    "from arcgis._impl.common._utils import zipws\n",
     "import shutil"
    ]
   },
@@ -55,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 4,
    "metadata": {
     "collapsed": false
    },
@@ -77,19 +76,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 5,
    "metadata": {
     "collapsed": true
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Folder already exists.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "# create a new folder in the GIS to store the layers (if it doesn't already exist)\n",
     "folder = os.path.basename(dir_path)\n",
@@ -107,15 +98,15 @@
     "# loop through shapefiles, zip them for upload, upload layers to GIS, move to new folder\n",
     "for i, shp_path in enumerate(shp_paths):\n",
     "    # create a temp dir to work in\n",
-    "    temp_dir = tempfile.mkdtemp()\n",
-    "    try:\n",
+    "    with tempfile.TemporaryDirectory() as temp_dir:\n",
     "        # copy all shapefile files into temp dir and zip the dir.\n",
     "        temp_shp_dir = os.path.join(temp_dir, os.path.splitext(os.path.basename(shp_path))[0])\n",
     "        os.makedirs(temp_shp_dir)\n",
     "        for ext in ['.shp', '.dbf', '.cpg', '.prj', '.sbn', '.sbx', '.shp.xml', '.shx']:\n",
     "            if os.path.exists(os.path.splitext(shp_path)[0] + ext):\n",
     "                shutil.copy(os.path.splitext(shp_path)[0]+ext, temp_shp_dir)\n",
-    "        shp_zip = zipws(path=temp_shp_dir, outfile=temp_shp_dir +'.zip', keep=False)\n",
+    "                \n",
+    "        shp_zip = shutil.make_archive(temp_shp_dir, 'zip', root_dir=temp_shp_dir)\n",
     "        \n",
     "        # publish the shapefile zip\n",
     "        title = os.path.splitext(os.path.basename(shp_path))[0]\n",
@@ -133,9 +124,6 @@
     "        # move the newly uploaded item to the folder created earlier\n",
     "        item.move(folder)\n",
     "        features_service.move(folder)\n",
-    "    finally:\n",
-    "        # clean up temp dir\n",
-    "        shutil.rmtree(temp_dir)\n",
     "    \n",
     "    print(\"{0}/{1}\".format(i + 1, len(shp_paths)))\n"
    ]

--- a/bulk_shp/bulk_shapefile_upload.ipynb
+++ b/bulk_shp/bulk_shapefile_upload.ipynb
@@ -1,0 +1,165 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Bulk Shapefile Upload\n",
+    "*A notebook to read shapefiles and upload their data as [hosted feature layers](https://doc.arcgis.com/en/arcgis-online/share-maps/hosted-web-layers.htm) in ArcGIS*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# common imports\n",
+    "import os\n",
+    "from arcgis.gis import *\n",
+    "from arcgis._impl.common._utils import zipws\n",
+    "import shutil"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## User Input\n",
+    "\n",
+    "* **gis**: your GIS instance, parameter information [here](https://developers.arcgis.com/python/guide/using-the-gis/)\n",
+    "* **dir_path**: path to directory with the Shapefiles"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "gis = GIS(\"https://www.arcgis.com\", \"<USERNAME>\", \"<PASSWORD>\")\n",
+    "\n",
+    "dir_path = \"<DIRECTORY PATH>\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Execution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Pushing 2 shapefile(s)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# get an array of all the shapefiles in the directory\n",
+    "shapefiles = [file for file in os.listdir(dir_path) if file.endswith('.shp')]\n",
+    "shp_paths = [os.path.join(dir_path, file) for file in shapefiles]\n",
+    "print(\"Pushing {0} shapefile(s)\".format(len(shp_paths)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Folder already exists.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# create a new folder in the GIS to store the layers (if it doesn't already exist)\n",
+    "folder = os.path.basename(dir_path)\n",
+    "gis_folder = gis.content.create_folder(folder)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "# loop through shapefiles, zip them for upload, upload layers to GIS, move to new folder\n",
+    "for i, shp_path in enumerate(shp_paths):\n",
+    "    # create a temp dir to work in\n",
+    "    temp_dir = tempfile.mkdtemp()\n",
+    "    try:\n",
+    "        # copy all shapefile files into temp dir and zip the dir.\n",
+    "        temp_shp_dir = os.path.join(temp_dir, os.path.splitext(os.path.basename(shp_path))[0])\n",
+    "        os.makedirs(temp_shp_dir)\n",
+    "        for ext in ['.shp', '.dbf', '.cpg', '.prj', '.sbn', '.sbx', '.shp.xml', '.shx']:\n",
+    "            if os.path.exists(os.path.splitext(shp_path)[0] + ext):\n",
+    "                shutil.copy(os.path.splitext(shp_path)[0]+ext, temp_shp_dir)\n",
+    "        shp_zip = zipws(path=temp_shp_dir, outfile=temp_shp_dir +'.zip', keep=False)\n",
+    "        \n",
+    "        # publish the shapefile zip\n",
+    "        title = os.path.splitext(os.path.basename(shp_path))[0]\n",
+    "        item = gis.content.add(data=shp_zip, item_properties={\n",
+    "            \"title\": title,\n",
+    "            'type': 'Shapefile',\n",
+    "            \"tags\": title})\n",
+    "        # see also: https://developers.arcgis.com/rest/services-reference/feature-service.htm\n",
+    "        features_service = item.publish({\n",
+    "            \"name\": os.path.splitext(item['name'])[0],\n",
+    "            \"hasStaticData\": True,\n",
+    "            \"layerInfo\": {\"capabilities\": \"Query\"}\n",
+    "        })\n",
+    "        \n",
+    "        # move the newly uploaded item to the folder created earlier\n",
+    "        item.move(folder)\n",
+    "        features_service.move(folder)\n",
+    "    finally:\n",
+    "        # clean up temp dir\n",
+    "        shutil.rmtree(temp_dir)\n",
+    "    \n",
+    "    print(\"{0}/{1}\".format(i + 1, len(shp_paths)))\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This was something I had trouble with when first approaching the python api, so here's an example for others to use. Uploading file GDBs is almost exactly the same process, but I thought this would be more helpful as an initial example.

What do you think of the use of the protected method `arcgis._impl.common._utils.zipws()`? Purity-wise it's bad practice to use protected methods, but since the content manager uses this internally to upload layers I thought it made good sense. Maybe we need a public method for importing a shapefile that will handle the zipping?

I wasn't able to confirm, but I think there's a limit to how many records can be imported this way, but I'm not sure. Can we document this if we can figure out what the limit is?
